### PR TITLE
feat: Lighthouse provider

### DIFF
--- a/ape_lighthouse/__init__.py
+++ b/ape_lighthouse/__init__.py
@@ -1,6 +1,6 @@
 from ape import plugins
 
-from .providers import LighthouseProvider
+from .provider import LighthouseProvider
 
 NETWORKS = {
     "beacon": [

--- a/ape_lighthouse/__init__.py
+++ b/ape_lighthouse/__init__.py
@@ -1,1 +1,17 @@
-# Add module top-level imports here
+from ape import plugins
+
+from .providers import LighthouseProvider
+
+NETWORKS = {
+    "beacon": [
+        "mainnet",
+        "goerli",
+    ],
+}
+
+
+@plugins.register(plugins.ProviderPlugin)
+def providers():
+    for ecosystem_name in NETWORKS:
+        for network_name in NETWORKS[ecosystem_name]:
+            yield ecosystem_name, network_name, LighthouseProvider

--- a/ape_lighthouse/provider.py
+++ b/ape_lighthouse/provider.py
@@ -12,7 +12,7 @@ DEFAULT_SETTINGS = {"uri": "http://localhost:5052"}
 
 
 # SEE: https://github.com/ApeWorX/ape/blob/main/src/ape_geth/provider.py#L147
-class Lighthouse(BeaconProvider, UpstreamProvider):
+class LighthouseProvider(BeaconProvider, UpstreamProvider):
     name: str = "lighthouse"
 
     @property

--- a/ape_lighthouse/provider.py
+++ b/ape_lighthouse/provider.py
@@ -1,0 +1,92 @@
+import requests
+from ape.api.providers import UpstreamProvider
+from ape.exceptions import ProviderError
+from ape.logging import logger
+from web3.beacon import Beacon
+from yarl import URL
+
+from ape_beacon.providers import BeaconProvider
+
+
+DEFAULT_SETTINGS = {"uri": "http://localhost:5052"}
+
+
+# SEE: https://github.com/ApeWorX/ape/blob/main/src/ape_geth/provider.py#L147
+class Lighthouse(BeaconProvider, UpstreamProvider):
+    name: str = "lighthouse"
+
+    @property
+    def uri(self) -> str:
+        if "uri" in self.provider_settings:
+            # Use adhoc, scripted value
+            return self.provider_settings["uri"]
+
+        config = self.config.dict().get(self.network.ecosystem.name, None)
+        if config is None:
+            return DEFAULT_SETTINGS["uri"]
+
+        # Use value from config file
+        network_config = config.get(self.network.name)
+        return network_config.get("uri", DEFAULT_SETTINGS["uri"])
+
+    @property
+    def _clean_uri(self) -> str:
+        return str(URL(self.uri).with_user(None).with_password(None))
+
+    @property
+    def connection_str(self) -> str:
+        return self.uri
+
+    def connect(self):
+        self._client_version = None  # Clear cached version when connecting to another URI.
+        self._beacon = Beacon(self.uri)
+
+        if not self.is_connected:
+            # TODO: "ephemeral" lighthouse?
+            raise ProviderError(f"No node found on '{self._clean_uri}'")
+        elif "lighthouse" in self.client_version.lower():
+            self._log_connection("Lighthouse")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        elif "prysm" in self.client_version.lower():
+            self._log_connection("Prysm")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        elif "lodestar" in self.client_version.lower():
+            self._log_connection("Lodestar")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        elif "nimbus" in self.client_version.lower():
+            self._log_connection("Nimbus")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        elif "teku" in self.client_version.lower():
+            self._log_connection("Teku")
+            # TODO: self.concurrency = ...
+            # TODO: self.block_page_size = ...
+        else:
+            client_name = self.client_version.split("/")[0]
+            logger.warning(
+                f"Connecting Lighthouse plugin to non-Lighthouse client '{client_name}'."
+            )
+
+        # Check for chain errors, including syncing
+        try:
+            # use deposit contract endpoint for chain ID
+            resp = self._beacon.get_deposit_contract()
+            chain_id = int(resp["data"]["chain_id"])
+        except (requests.exceptions.HTTPError, KeyError) as err:
+            raise ProviderError(
+                err.args[0].get("message")
+                if all((hasattr(err, "args"), err.args, isinstance(err.args[0], dict)))
+                else "Error getting chain id."
+            )
+
+        self.network.verify_chain_id(chain_id)
+
+    def disconnect(self):
+        self._beacon = None
+        self._client_version = None
+
+    def _log_connection(self, client_name: str):
+        logger.info(f"Connecting to existing {client_name} node at '{self._clean_uri}'.")

--- a/ape_lighthouse/provider.py
+++ b/ape_lighthouse/provider.py
@@ -2,11 +2,9 @@ import requests
 from ape.api.providers import UpstreamProvider
 from ape.exceptions import ProviderError
 from ape.logging import logger
+from ape_beacon.providers import BeaconProvider
 from web3.beacon import Beacon
 from yarl import URL
-
-from ape_beacon.providers import BeaconProvider
-
 
 DEFAULT_SETTINGS = {"uri": "http://localhost:5052"}
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require = {
         "mypy>=0.971",  # Static type analyzer
         "flake8>=4.0.1",  # Style linter
         "isort>=5.10.1",  # Import sorting linter
+        "types-requests",  # NOTE: Needed due to mypy typeshed
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import ape
+import pytest
+
+from ape_lighthouse import LighthouseProvider
+
+
+@pytest.fixture
+def networks():
+    return ape.networks
+
+
+@pytest.fixture
+def lighthouse_provider(networks) -> LighthouseProvider:
+    return networks.beacon.goerli.get_provider("lighthouse")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,20 @@
+import pytest
+from ape import networks
+
+from ape_lighthouse.provider import LighthouseProvider
+
+
+@pytest.mark.parametrize(
+    "ecosystem,network",
+    [
+        ("beacon", "mainnet"),
+        ("beacon", "goerli"),
+    ],
+)
+def test_lighthouse(ecosystem, network):
+    ecosystem_cls = networks.get_ecosystem(ecosystem)
+    network_cls = ecosystem_cls.get_network(network)
+    with network_cls.use_provider("lighthouse") as provider:
+        assert isinstance(provider, LighthouseProvider)
+        assert provider.get_balance("0")  # validator index == 0
+        assert provider.get_block("latest")


### PR DESCRIPTION
### What I did

Added Lighthouse provider for connecting with Beacon chain.

### How I did it

Moved `LighthouseProvider` from `ape-beacon` into this repo. Resolves naming issues in [#11](https://github.com/fmrmf/ape-beacon/issues/11).

### How to verify it

Start your lighthouse node

```sh
lighthouse bn --http
```

run in `ape-lighthouse` dir

```sh
python
```

then e.g.

```python
>>> from ape import networks
>>> with networks.beacon.mainnet.use_provider("lighthouse") as provider:
...    bal = provider.get_balance("0")
...    print('bal', bal)
... 
INFO: Connecting to existing Lighthouse node at 'http://localhost:5052'.
bal 33606621886
```


### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
